### PR TITLE
Remove node-fetch dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
 
       - run: |
           npm install
-          spago build
+          spago -x test.dhall build
           node --experimental-fetch test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,5 @@ jobs:
 
       - run: |
           npm install
+          spago build
           node --experimental-fetch test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "17.5"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -36,4 +36,4 @@ jobs:
 
       - run: |
           npm install
-          spago -x test.dhall test
+          node --experimental-fetch test.js

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "node-fetch": "^3.2.4"
-  }
+  },
+  "type": "module"
 }

--- a/src/Yoga/Fetch/Impl/Node.js
+++ b/src/Yoga/Fetch/Impl/Node.js
@@ -1,1 +1,1 @@
-export { default as nodeFetch } from 'node-fetch';
+export const nodeFetch = fetch;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,2 @@
+import { main } from './output/Test.Main/index.js'
+main()


### PR DESCRIPTION
Starting with version 17.5 node ships with a (currently experimental) fetch api